### PR TITLE
Add tests and CI workflow

### DIFF
--- a/.github/workflows/flutter.yml
+++ b/.github/workflows/flutter.yml
@@ -1,0 +1,17 @@
+name: Flutter CI
+
+on:
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: subosito/flutter-action@v2
+        with:
+          flutter-version: '3.19.0'
+      - run: flutter pub get
+      - run: flutter analyze
+      - run: flutter test

--- a/test/event_evaluator_test.dart
+++ b/test/event_evaluator_test.dart
@@ -1,0 +1,43 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:go_stop_app/utils/event_evaluator.dart';
+import 'package:go_stop_app/models/card_model.dart';
+
+GoStopCard c(int month, String type, {String name = ''}) =>
+    GoStopCard(id: month, month: month, type: type, name: name, imageUrl: '');
+
+void main() {
+  test('isChok detects chok event', () {
+    final played = c(1, '피');
+    final drawn = c(2, '피');
+    final field = [c(2, '띠')];
+    expect(EventEvaluator.isChok(played, drawn, field), isTrue);
+  });
+
+  test('isTtak detects ttak event', () {
+    final played = c(3, '피');
+    final field = [c(3, '피'), c(3, '띠')];
+    expect(EventEvaluator.isTtak(played, field), isTrue);
+  });
+
+  test('isBomb detects bomb event', () {
+    final hand = [c(4, '피'), c(4, '띠'), c(4, '광')];
+    final field = [c(4, '피')];
+    expect(EventEvaluator.isBomb(hand, field), isTrue);
+  });
+
+  test('isPuk updates history when puk occurs', () {
+    final ev = EventEvaluator();
+    final played = c(5, '피');
+    final field = [c(5, '띠'), c(5, '피')];
+    expect(ev.isPuk(played, field), isTrue);
+    expect(ev.pukHistory.contains('5'), isTrue);
+  });
+
+  test('isTriplePuk returns true after three puks', () {
+    final ev = EventEvaluator();
+    for (var m in [6, 7, 8]) {
+      expect(ev.isPuk(c(m, '피'), [c(m, '피'), c(m, '띠')]), isTrue);
+    }
+    expect(ev.isTriplePuk(), isTrue);
+  });
+}

--- a/test/score_test.dart
+++ b/test/score_test.dart
@@ -1,0 +1,32 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:go_stop_app/utils/matgo_engine.dart';
+import 'package:go_stop_app/models/card_model.dart';
+
+GoStopCard c(int month, String type, {String name = ''}) =>
+    GoStopCard(id: month, month: month, type: type, name: name, imageUrl: '');
+
+void main() {
+  test('three gwang gives 3 points', () {
+    final engine = MatgoEngine();
+    engine.captured['player1'] = [c(1, '광'), c(2, '광'), c(3, '광')];
+    expect(engine.calculateScore('player1'), 3);
+  });
+
+  test('pi over 10 scores correctly', () {
+    final engine = MatgoEngine();
+    engine.captured['player1'] = [for (var i = 0; i < 11; i++) c(i, '피')];
+    expect(engine.calculateScore('player1'), 2);
+  });
+
+  test('godori adds 5 points', () {
+    final engine = MatgoEngine();
+    engine.captured['player1'] = [c(1, '동물'), c(3, '동물'), c(8, '동물')];
+    expect(engine.calculateScore('player1'), 5);
+  });
+
+  test('animal count seven doubles score', () {
+    final engine = MatgoEngine();
+    engine.captured['player1'] = [for (var i = 0; i < 7; i++) c(i, '동물')];
+    expect(engine.calculateScore('player1'), 6);
+  });
+}


### PR DESCRIPTION
## Summary
- add unit tests for event evaluator functions
- add unit tests covering score calculations
- setup GitHub Actions workflow to run `flutter analyze` and `flutter test`

## Testing
- `flutter test` *(fails: command not found)*
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68473c305e108325a6a889e74cc88ccf